### PR TITLE
250119 / 김영환

### DIFF
--- a/YOUNGHWAN/10867_중복_빼고_정렬하기.cpp
+++ b/YOUNGHWAN/10867_중복_빼고_정렬하기.cpp
@@ -1,0 +1,23 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, e;
+vector<int> v;
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n;
+    for (int i = 0; i < n; i++)
+    {
+        cin >> e;
+        v.push_back(e);
+    }
+    sort(v.begin(), v.end());
+    v.erase(unique(v.begin(), v.end()), v.end());
+
+    for (auto e : v)
+    {
+        cout << e << " ";
+    }
+}

--- a/YOUNGHWAN/1735_분수_합.cpp
+++ b/YOUNGHWAN/1735_분수_합.cpp
@@ -1,0 +1,25 @@
+#include <bits/stdc++.h>
+using namespace std;
+int a, b, c, d;
+int gcd(int m, int n)
+{
+    while (n != 0)
+    {
+        int r = m % n;
+        m = n;
+        n = r;
+    }
+    return m;
+}
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> a >> b;
+    cin >> c >> d;
+
+    int numerator = a * d + c * b;
+    int denominator = b * d;
+    int cd = gcd(numerator, denominator);
+    cout << numerator / cd << " " << denominator / cd;
+}

--- a/YOUNGHWAN/1920_수_찾기.cpp
+++ b/YOUNGHWAN/1920_수_찾기.cpp
@@ -1,0 +1,28 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, e, m, a;
+unordered_set<int> s;
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n;
+    for (int i = 0; i < n; i++)
+    {
+        cin >> e;
+        s.insert(e);
+    }
+
+    cin >> m;
+    for (int i = 0; i < m; i++)
+    {
+        cin >> a;
+        int res = 0;
+        if (s.find(a) != s.end())
+        {
+            res = 1;
+        }
+        cout << res << "\n";
+    }
+}

--- a/YOUNGHWAN/27496_발머의_피크_이론.cpp
+++ b/YOUNGHWAN/27496_발머의_피크_이론.cpp
@@ -1,0 +1,27 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, l, cnt = 0;
+long long sum;
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+
+    cin >> n >> l;
+    vector<int> v(n, 0);
+    for (int i = 0; i < n; i++)
+    {
+        cin >> v[i];
+        sum += v[i];
+        if (i >= l)
+        {
+            sum -= v[i - l];
+        }
+        if (129 <= sum && sum <= 138)
+        {
+            cnt++;
+        }
+    }
+    cout << cnt;
+}

--- a/YOUNGHWAN/9935_문자열_폭발.cpp
+++ b/YOUNGHWAN/9935_문자열_폭발.cpp
@@ -1,0 +1,51 @@
+#include <bits/stdc++.h>
+using namespace std;
+string s, des_s, res;
+stack<char> st;
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+
+    cin >> s >> des_s;
+    for (int i = 0; i < s.length(); i++)
+    {
+        st.push(s[i]);
+
+        if (s[i] == des_s[des_s.length() - 1] && st.size() >= des_s.length())
+        {
+            string dum;
+            for (int j = 0; j < des_s.length(); j++)
+            {
+                dum.push_back(st.top());
+                st.pop();
+            }
+
+            reverse(dum.begin(), dum.end());
+
+            if (dum.compare(des_s) != 0)
+            {
+                for (int k = 0; k < dum.length(); k++)
+                {
+                    st.push(dum[k]);
+                }
+            }
+        }
+    }
+
+    while (!st.empty())
+    {
+        res.push_back(st.top());
+        st.pop();
+    }
+
+    reverse(res.begin(), res.end());
+    if (res.empty())
+    {
+        cout << "FRULA";
+        return 0;
+    }
+    cout << res;
+    return 0;
+}


### PR DESCRIPTION
## 문제 번호/제목
[분수합](https://www.acmicpc.net/problem/1735)
[발머의 피크 이론](https://www.acmicpc.net/problem/27496)
[수 찾기](https://www.acmicpc.net/problem/1920)
[중복 빼고 정렬하기](https://www.acmicpc.net/problem/10867)
[문자열 폭발](https://www.acmicpc.net/problem/9935)

## 코드 설명
### [분수합](https://www.acmicpc.net/problem/1735)
기약 분수를 만드는 문제이다. 기약분수의 정의를 보면 바로 알 수 있는데, 최대 공약수로 분자와 분모를 나누면, 기약분수를 만들 수 있다. gcd를 사용해 만들었다.

### [발머의 피크 이론](https://www.acmicpc.net/problem/27496)
혈중 알콜 농도의 지속 시간을 구하는 문제이다. float point 연산으로 할라다 정확도를 위해 int 범위로 수평 이동해 풀었다. 시간 절약을 위해 슬라이딩 윈도우 기법으로 한번에 구했다.

### [수 찾기](https://www.acmicpc.net/problem/1920)
어떠한 배열에 해당하는 수가 있는지 찾는 문제이다. 난 set으로 받아 시간을 최대한 절약하여 문제를 풀었다.

### [중복 빼고 정렬하기](https://www.acmicpc.net/problem/10867)
배열의 중복을 제거하고 정렬하는 간단한 문제이다.

### [문자열 폭발](https://www.acmicpc.net/problem/9935)
문자열을 스택으로 접근하여 pop하는 형식의 자료구조 예제로 나올법한 문제이다. 지금 시간이 넉넉하지 않아... 자세한건 추후에 다시 적어두겠다...



## Reference



