### PR TITLE
250119 / 고건

### DIFF
--- a/Gun/11971_속도 위반.py
+++ b/Gun/11971_속도 위반.py
@@ -1,0 +1,24 @@
+import sys
+
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+a, b = [], []
+max_violation = 0
+
+for _ in range(n):
+    idx, deadline = map(int, input().split())
+    arr = [deadline] * idx
+    a.extend(arr)
+    
+for _ in range(m):
+    idx, speed = map(int, input().split())
+    arr = [speed] * idx
+    b.extend(arr)
+
+for i in range(100):
+    if a[i] < b[i]:
+        violation = b[i] - a[i]
+        max_violation = max(violation, max_violation)
+
+print(max_violation)

--- a/Gun/12015_가장 긴 증가하는 부분 수열 2.py
+++ b/Gun/12015_가장 긴 증가하는 부분 수열 2.py
@@ -1,0 +1,44 @@
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+a = list(map(int, input().split()))
+dp = [a[0]]
+
+def bi(arr, num):
+    start = 0
+    end = len(arr) - 1
+
+    while start <= end:
+        mid = (start + end) // 2
+        
+        if arr[mid] == num:
+            return mid
+        elif arr[mid] > num:
+            end = mid - 1
+        else:
+            start = mid + 1
+
+    return start
+
+for num in a:
+    if num > dp[-1]:
+        dp.append(num)
+    else:
+        idx = bi(dp, num)
+        dp[idx] = num
+
+print(len(dp))
+
+# Sol 2. bisect_left 사용
+from bisect import bisect_left
+
+for num in a:
+    if num > dp[-1]:
+        dp.append(num)
+    else:
+        idx = bisect_left(dp, num)
+        dp[idx] = num
+
+print(len(dp))

--- a/Gun/14002_가장 긴 증가하는 부분 수열 4.py
+++ b/Gun/14002_가장 긴 증가하는 부분 수열 4.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+a = list(map(int, input().split()))
+dp = [1] * n
+
+for i in range(1, n):
+    for j in range(i):
+        if a[i] > a[j]:
+            dp[i] = max(dp[i], dp[j] + 1)
+
+res = []
+x = max(dp)
+print(x)
+
+for i in range(n - 1, -1, -1):
+    if x == dp[i]:
+        res.append(a[i])
+        x -= 1
+
+print(*reversed(res))

--- a/Gun/14003_가장 긴 증가하는 부분 수열 5.py
+++ b/Gun/14003_가장 긴 증가하는 부분 수열 5.py
@@ -1,0 +1,38 @@
+import sys
+from bisect import bisect_left
+
+input = sys.stdin.readline
+
+N = int(input())
+a = list(map(int, input().split()))
+
+def l(arr):
+    n = len(arr)
+    dp = [arr[0]]
+    seq = [1]
+    max_seq = 1
+    
+    for i in range(1, n):
+        if dp[-1] < arr[i]:
+            dp.append(arr[i])
+            seq.append(max_seq + 1)
+        else:
+            idx = bisect_left(dp, a[i])
+            dp[idx] = arr[i]
+            seq.append(idx + 1)
+            
+        max_seq = max(max_seq, seq[-1])  
+    
+    return seq
+
+s = l(a)
+x = max(s)
+print(x)
+
+res = []
+for j in range(N - 1, -1, -1):
+    if s[j] == x:
+        res.append(a[j])
+        x -= 1
+
+print(*res[::-1])

--- a/Gun/2108_통계학.py
+++ b/Gun/2108_통계학.py
@@ -1,0 +1,32 @@
+import sys
+from collections import Counter
+
+input = sys.stdin.readline
+
+n = int(input())
+a = []
+
+for _ in range(n):
+    a.append(int(input().rstrip()))
+
+# 산술평균
+print(round(sum(a) / n))
+
+# 중앙값
+print(sorted(a)[n // 2])
+
+# 최빈값
+d = dict(Counter(a))
+max_cnt = max(d.values())
+l = []
+
+for v in d.keys():
+    if d[v] == max_cnt:
+        l.append(v)
+
+if len(l) == 1:
+    print(l[0])
+else:
+    print(sorted(l)[1])        
+# 범위
+print(max(a) - min(a))


### PR DESCRIPTION
## 문제 번호/제목


[통계학](https://www.acmicpc.net/problem/2108)

[속도 위반](https://www.acmicpc.net/problem/11971)

[가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015)

[가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002)

[가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/14003)


## 코드 설명

[통계학](https://www.acmicpc.net/problem/2108)

주어진 수열의 산술 평균, 중앙값, 최빈값, 범위를 구하는 문제이다. 최빈값을 구하는 조건이 까다로웠는데, 최빈값이 여러 가지일 때 두 번째로 작은 값을 출력하기 때문이었다. 나는 Python의 Counter를 이용했다. Counter는 key-value형태로 주어진 수열의 값과 빈도 수를 나타내준다. 말 그대로 등장 횟수를 세어주는 것이다.

카운터를 활용하여 주어진 수열의 최빈값의 횟수를 구하는 코드이다.

```
from collections import Counter

d = dict(Counter(a))
max_cnt = max(d.values())
```

[속도 위반](https://www.acmicpc.net/problem/11971)

전체 길이가 100인 도로의 구간별 제한 속도 정보, 주행 거리 정보가 주어지고 속도를 위반했을 때 그 차이의 최댓값을 구하는 문제이다. 길이가 100이므로 100짜리 배열을 두 개 만들고 한 번의 순회로 위반한 경우의 최댓값을 구하였다.

[가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015)

이전 문제인 [가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053) 과 같은 조건의 문제이다. 그러나 수열의 길이가 1000에서 100만으로 늘어났다. 이전의 DP 풀이는 O(n^2)이었지만 이번 문제는 그렇게 풀면 시간 초과가 날 것이므로, O(nlogn)의 풀이를 생각해야 한다. 이분 탐색을 떠올렸지만, 어떤 배열을 이분 탐색해야 하는지 아이디어가 쉽게 떠오르지 않았다. 질문 게시판과 풀이를 참고해본 결과 dp배열을 통해 기존 수열의 값을 하나씩 받아가는데, dp배열의 마지막 수보다 다음에 오는 수가 크면 dp의 마지막에 수를 추가하고, 작다면 dp배열의 이분 탐색을 통해 해당 수의 인덱스 자리에 다음 수를 넣는 방식이다. 이렇게 되면 마지막 dp의 길이는 전체 수열 중 가장 긴 길이의 증가하는 수열의 길이가 될 것이다. 하지만 그 수열 자체의 정보를 가지고 있지는 않다. 

우리는 수열의 길이만 알면 되므로, 이러한 방법으로 O(nlogn) 시간 안에 해결할 수 있게 되었다.

[가장 긴 증가하는 부분 수열 4](https://www.acmicpc.net/problem/14002)

바로 전 문제에서 우려한, 수열의 정보까지 출력하는 문제가 나왔다. 이 문제도 고민에 고민을 거듭한 끝에, 수열의 수를 받아서 저장하는 dp배열의 용도를 다르게 해야 한다는 것을 알게 되었다. Dp배열은 단순히 숫자가 몇 번째로 큰 수인지에 대한 정보만 저장하고, 나중에 수열의 오른쪽 끝부터 반대로 탐색해 순번이 가장 큰 인덱스의 숫자부터 차례로 정답 배열에 담은 다음, 이를 reverse해서 출력하면 되었다. 

```
for i in range(n):
    for j in range(i):
        dp[i] = max(dp[i], dp[j] + 1)
```

이 문제는 N <= 1000이어서 시간 복잡도에 대한 부담을 없었다.

[가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/14003)

지독한 수열 문제들의 모든 최악의 조건을 다 합친 문제이다. 수열 자체를 출력해야 하고, N <= 100만 이하이기 때문에 4번 문제대로 풀면 시간 초과가 나게 된다. 하지만 메커니즘은 같을 것이므로, 이전에 만든 수열의 순번을 저장하는 배열을 O(nlogn)으로 만들 수 있는 풀이를 생각해보았다. 그래서 추가로 seq배열을 만든 후, 이분 탐색에서 수열의 숫자를 받았던 dp배열도 같이 이용하여 구현하였다.

## Reference




