### PR TITLE
2501126/한승훈

### DIFF
--- a/SeungHoon/6주차/11050_SeungHoon.py
+++ b/SeungHoon/6주차/11050_SeungHoon.py
@@ -1,4 +1,4 @@
-# [BOJ] 이항 계수 1 / Bronze 1 / 20m
+# [BOJ] 이항 계수 1 / Bronze 1 / 20m 
 N, K = map(int,input().split())
 
 numerator = 1

--- a/SeungHoon/6주차/11724_SeungHoon.py
+++ b/SeungHoon/6주차/11724_SeungHoon.py
@@ -1,4 +1,4 @@
-# [BOJ] 연결 요소의 개수 / Silver 2 / 1h
+# [BOJ] 연결 요소의 개수 / Silver 2 / 1h 
 import sys
 sys.setrecursionlimit(10**6)
 N, M = map(int,sys.stdin.readline().split())

--- a/SeungHoon/6주차/11866_SeungHoon.py
+++ b/SeungHoon/6주차/11866_SeungHoon.py
@@ -1,4 +1,4 @@
-# 요세푸스 문제 0 / Silver 4 / 1h
+# [BOJ]요세푸스 문제 0 / Silver 4 / 1h
 N, K = map(int,input().split())
 
 arr = []

--- a/SeungHoon/6주차/11866_SeungHoon.py
+++ b/SeungHoon/6주차/11866_SeungHoon.py
@@ -1,4 +1,4 @@
-# [BOJ]요세푸스 문제 0 / Silver 4 / 1h
+# [BOJ]요세푸스 문제 0 / Silver 4 / 1h 
 N, K = map(int,input().split())
 
 arr = []

--- a/SeungHoon/6주차/1931_SeungHoon.py
+++ b/SeungHoon/6주차/1931_SeungHoon.py
@@ -1,4 +1,4 @@
-#[BOJ] 회의실 배정 / Gold 5 / 30m
+#[BOJ] 회의실 배정 / Gold 5 / 30m 
 import sys
 N = int(sys.stdin.readline())
 

--- a/SeungHoon/6주차/3986_SeungHoon.py
+++ b/SeungHoon/6주차/3986_SeungHoon.py
@@ -1,4 +1,4 @@
-#[BOJ] 좋은 단어 / Silver 4 / 30m
+#[BOJ] 좋은 단어 / Silver 4 / 30m 
 N = int(input())
 
 count = 0


### PR DESCRIPTION
## 문제 번호/제목
### [1931/회의실 배정](https://www.acmicpc.net/problem/1931)
### [3986/좋은 단어](https://www.acmicpc.net/problem/3986)
### [11050/이항 계수 1](https://www.acmicpc.net/problem/11050)
### [11724/연결 요소의 개수](https://www.acmicpc.net/problem/11724)
### [11866/요세푸스 문제 0](https://www.acmicpc.net/problem/11866)

## 코드 설명
### [1931/회의실 배정](https://www.acmicpc.net/problem/1931)
처음 반복문 조건을 이런식으로 적었더니 틀렸다.
```
count = 0
start = 0
end = 0
for i in range(N):
  if(arr[i][0] > end):
    start = arr[i][0]
    end = arr[i][1]
    count += 1
```
생각 해보니 회의 시작시간은 굳이 필요가 없어서 빼고 반복문 조건을 수정하니 맞았다.
그리디 알고리즘으로 푸는 문제.
직전 회의가 끝나는 시간부터 시작하는 가장 빨리 끝나는 회의를 골라서
개수를 집계

### [3986/좋은 단어](https://www.acmicpc.net/problem/3986)
처음에 리스트 마지막 값을 제거하기 위해 arr.remove(string[j]) 이딴식으로 작성했다가 틀렸다.
저건 배열의 특정한 값을 제거하기 때문에 옳지 않다.
arr.pop(index)를 쓰자
나머지는 괄호 문제와 크게 다를게 없었다.

### [11050/이항 계수 1](https://www.acmicpc.net/problem/11050)
이항계수 = 조합(Combination) 이었다.
분자, 분모를 입력값에서부터 역순으로 곱해준다
분자는 카운트를 추가해서 K번 반복하게 만든다.

### [11724/연결 요소의 개수](https://www.acmicpc.net/problem/11724)
간단한 그래프 탐색 문제
해당 문제는 DFS(깊이 우선 탐색)으로 풀었다.
먼저 그래프를 위한 2차원 배열을 만든 후
graph[x].append(y)
graph[y].append(x)
로 인접 리스트를 만든다.
방문 확인을 위한 visited 배열을 만든 후 False로 초기화 한다.
dfs를 돌면서 그래프 배열, 인덱스, 방문 배열을 파라미터로 넘긴다.
그래프 안에 인접한 노드의 인덱스를 찾아가 방문 표시를 한다.
하나의 싸이클을 찾고 난 후 count + 1을 해준다.
시간초과가 떠서 sys.stdin.readline()을 이용했다.

### [11866/요세푸스 문제 0](https://www.acmicpc.net/problem/11866)
```
1234567
124567 3
12457 36
1457 362
145 3627
14 36275
4 362751
```
위와 같은 형식으로 진행된다
인덱스를 계산하는 방법을 계속 고민하다가
현재 배열의 길이 % (K - 1)가 인덱스가 된다는 사실을 알아냈다.

## Reference
[그래프 구현](https://classic-griver.tistory.com/192)


