### PR TITLE
250209/김지나

### DIFF
--- a/Jina/11279_최대 힙.py
+++ b/Jina/11279_최대 힙.py
@@ -1,0 +1,17 @@
+import sys
+import heapq
+input = sys.stdin.readline
+heap = []
+
+n = int(input())
+
+for _ in range(n):
+    x = int(input())
+
+    if x == 0:
+        if len(heap):
+            print(-heapq.heappop(heap))
+        else:
+            print(0)
+    else:
+        heapq.heappush(heap, -x)

--- a/Jina/1463_1로 만들기.py
+++ b/Jina/1463_1로 만들기.py
@@ -1,0 +1,15 @@
+N = int(input())
+
+dp = [0] * ( N + 1)
+
+#dp[i] : 숫자 i를 만드는데 필요한 최소 연산 횟수
+for i in range (2, N+1) :
+    dp[i] = dp[i-1] + 1 
+    
+    if i % 2 == 0: # 2로 나누어 떨어지는 경우, 최소값 갱신
+        dp[i] = min(dp[i], dp[i//2] + 1) 
+    
+    if i % 3 == 0 :# 3으로 나누어 떨어지는 경우, 최소값 갱신
+        dp[i] = min(dp[i], dp[i//3] + 1)
+
+print(dp[N])

--- a/Jina/1927_최소 힙.py
+++ b/Jina/1927_최소 힙.py
@@ -1,0 +1,17 @@
+import sys
+import heapq
+input = sys.stdin.readline
+
+n = int(input())
+heap = []
+
+for _ in range(n):
+    x = int(input())
+
+    if x == 0:
+        if len(heap):
+            print(heapq.heappop(heap))
+        else: 
+            print(0)
+    else:
+        heapq.heappush(heap, x)

--- a/Jina/2748_피보나치 수 2.py
+++ b/Jina/2748_피보나치 수 2.py
@@ -1,0 +1,12 @@
+n = int(input())
+
+if n == 0:
+    print(0)
+elif n == 1:
+    print(1)
+else:
+    fib = [0] * (n + 1)
+    fib[1] = 1
+    for i in range(2, n + 1):
+        fib[i] = fib[i - 1] + fib[i - 2]
+    print(fib[n])

--- a/Jina/9095_123 더하기.py
+++ b/Jina/9095_123 더하기.py
@@ -1,0 +1,18 @@
+T = int(input())
+
+for _ in range(T):
+    n = int(input())
+    dp = [0] * (n + 1)
+
+    for i in range(1, n+1):
+        if i == 1:
+            dp[1] = 1
+        elif i == 2:
+            dp[2] = 2
+        elif i == 3:
+            dp[3] = 4
+        else:
+            dp[i] = dp[i-1] + dp[i-2] + dp[i-3]
+
+    print(dp[n])
+    


### PR DESCRIPTION
## 문제 번호/제목

[피보나치 수 2](https://www.acmicpc.net/problem/2748)
[1로 만들기](https://www.acmicpc.net/problem/1463)
[최소 힙](https://www.acmicpc.net/problem/1927)
[최대 힙](https://www.acmicpc.net/problem/11279)
[1, 2, 3 더하기](https://www.acmicpc.net/problem/9095)

## 코드 설명

[피보나치 수 2](https://www.acmicpc.net/problem/2748)

처음엔 그냥 재귀로 풀었다가 시간초과가 나서 다시 풀었다.
n이 0과 1일 땐 각각 0과 1의 값을 가지므로 미리 dp배열에 저장해두고, 반복문을 통해 2부터 n까지 순차적으로 구해줬다.

[1로 만들기](https://www.acmicpc.net/problem/1463)

정수 N이 주어졌을때, 3으로 나누기, 2로 나누기, 1을 더하기 <- 이 세가지 연산을 활용하여 1을 만들 때 최소 연산 횟수를 구하는 문제이다. 
처음 두 수를 알기 때문에 상향식(bottom-up)으로 풀 수 있다.

X = 10인 경우, 10 -> 9 -> 3 -> 1  과정을 거쳐 1이 되게 되는데
9의 경우에는 또, 9 -> 3 -> 1의 과정을 거치며
3의 경우에는 3 -> 1의 과정을 거친다.
즉, 10을 구할 때는 9의 결과를, 9를 구할 때는 3의 결과를 이용한다.
앞에서 구한 결과값을 저장했다가 후에 사용하도록 했다.
그리고, 2와 3으로 나누어 떨어지지 않는 경우는 무조건 1을 빼야 하기 때문에
dp[i] = dp[i-1] + 1을 통해 횟수를 +1 해준다.
그리고나서, dp[i]가 2 와 3으로 나누어 떨어지는 경우에는 dp[i](1을 빼는 경우)와 dp[i//2or3]+1(나누었을 경우) 중 최소값을 선택한다.

[최소 힙](https://www.acmicpc.net/problem/1927)

입력되는 수가 0일 때는 heap에서 가장 작은 수를 pop하고, 자연수일때는 heap에 push하는 문제다.
heapq.heappop(list) 을 하게 되면 힙에서 가장 작은 아이템을 빼고 반환한다. 파이썬의 heapq 모듈은 기본적으로 최소힙으로 사용할 수 있기에 편하게 풀었다. 

[최대 힙](https://www.acmicpc.net/problem/11279)

입력되는 수가 0일 때는 heap에서 가장 큰 수를 pop하고, 자연수일때는 heap에 push하는 문제다.
최소 힙을 구현했던 과정에서 push하고 pop할 때의 수를 음수로 바꾸면 쉽게 풀 수 있다.

[1, 2, 3 더하기](https://www.acmicpc.net/problem/9095)

dp[1]~dp[6]까지 직접 적어보며 점화식을 구해보았다. 
예를 들어 dp[4] = dp[3] + dp[2] + dp[1] = 4+2+1 = 7 이 나온다. 
따라서 i >= 4 일 때, dp [i] = dp[i-1] + dp[i-2] + dp[i-3] 이라는 식이 나온다.

## Reference



