### PR TITLE
250209/ 김영환

### DIFF
--- a/YOUNGHWAN/11662_민호와_강호.cpp
+++ b/YOUNGHWAN/11662_민호와_강호.cpp
@@ -1,0 +1,45 @@
+#include <bits/stdc++.h>
+using namespace std;
+int Ax, Ay, Bx, By, Cx, Cy, Dx, Dy;
+pair<double, double> minho(double p)
+{
+    return make_pair(Ax + (Bx - Ax) * (p / 100), (Ay + (By - Ay) * (p / 100)));
+}
+pair<double, double> kangho(double p)
+{
+    return make_pair(Cx + (Dx - Cx) * (p / 100), (Cy + (Dy - Cy) * (p / 100)));
+}
+int main()
+{
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+    cin >> Ax >> Ay >> Bx >> By >> Cx >> Cy >> Dx >> Dy;
+
+    double l(0), h(100), minRes = 20000, p, q;
+    while (h - l >= 1e-6)
+    {
+        p = (2 * l + h) / 3;
+        q = (l + 2 * h) / 3;
+
+        pair<double, double> m_p = minho(p);
+        pair<double, double> m_q = minho(q);
+        pair<double, double> k_p = kangho(p);
+        pair<double, double> k_q = kangho(q);
+
+        double ptimeD = sqrt(pow(m_p.first - k_p.first, 2) + pow(m_p.second - k_p.second, 2));
+        double qtimeD = sqrt(pow(m_q.first - k_q.first, 2) + pow(m_q.second - k_q.second, 2));
+
+        minRes = min(minRes, min(ptimeD, qtimeD));
+        if (ptimeD > qtimeD)
+        {
+            l = p;
+        }
+        else
+        {
+            h = q;
+        }
+    }
+    cout.precision(10);
+    cout << minRes << endl;
+}

--- a/YOUNGHWAN/11724_연결_요소의_개수.cpp
+++ b/YOUNGHWAN/11724_연결_요소의_개수.cpp
@@ -1,0 +1,42 @@
+#include <bits/stdc++.h>
+#define MAX 1004
+using namespace std;
+int N, M, u, v, ret;
+int arr[MAX][MAX];
+bool vs[MAX];
+void dfs(int v)
+{
+    vs[v] = true;
+    for (auto i = 0; i <= N; i++)
+    {
+        if (vs[i] == true || arr[v][i] == 0)
+        {
+            continue;
+        }
+        dfs(i);
+    }
+}
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    cout.tie(0);
+
+    cin >> N >> M;
+    while (M--)
+    {
+        cin >> u >> v;
+        arr[u][v] = 1;
+        arr[v][u] = 1;
+    }
+    for (auto i = 1; i <= N; i++)
+    {
+        if (vs[i] == false)
+        {
+            ret++;
+            dfs(i);
+        }
+    }
+
+    cout << ret << "\n";
+}

--- a/YOUNGHWAN/1629_곱셈.cpp
+++ b/YOUNGHWAN/1629_곱셈.cpp
@@ -1,0 +1,26 @@
+#include <bits/stdc++.h>
+using namespace std;
+int a, b, c, res;
+
+long long d;
+long long f(long long int y)
+{
+    if (y == 0 || y == 1)
+        return a % c;
+    long long k = f(y / 2) % c;
+    if (y % 2 == 0)
+        return k * k % c;
+    else
+        return k * k % c * a % c;
+}
+int main()
+{
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+
+    cin >> a >> b >> c;
+    res = f(b);
+    cout << res;
+    return 0;
+}

--- a/YOUNGHWAN/20153_영웅좌_문제.cpp
+++ b/YOUNGHWAN/20153_영웅좌_문제.cpp
@@ -1,0 +1,31 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, res;
+int max(int a, int b)
+{
+    if (a > b)
+    {
+        return a;
+    }
+    return b;
+}
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n;
+    vector<int> v(n);
+    for (auto &i : v)
+    {
+        cin >> i;
+        res ^= i;
+    }
+    int curMax = 0;
+    for (const auto &i : v)
+    {
+        curMax = max(curMax, (res ^ i));
+    }
+    curMax = max(curMax, res);
+    cout << curMax << curMax;
+}

--- a/YOUNGHWAN/7490_0_만들기.cpp
+++ b/YOUNGHWAN/7490_0_만들기.cpp
@@ -1,0 +1,34 @@
+#include <bits/stdc++.h>
+using namespace std;
+int N;
+int t;
+void dfs(int sum, int sign, int num, int n, string str)
+{
+    if (n == t)
+    {
+        sum += (num * sign);
+        if (sum == 0)
+        {
+            cout << str << '\n';
+        }
+    }
+    else
+    {
+        dfs(sum, sign, num * 10 + (n + 1), n + 1, str + ' ' + char(n + 1 + '0'));
+        dfs(sum + (sign * num), 1, n + 1, n + 1, str + '+' + char(n + 1 + '0'));
+        dfs(sum + (sign * num), -1, n + 1, n + 1, str + '-' + char(n + 1 + '0'));
+    }
+}
+// 수식의 경우의 수 3개 최대 3^10이다. 완전탐색으로 풀 수 있을거 같다.
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> N;
+    for (int i = 0; i < N; i++)
+    {
+        cin >> t;
+        dfs(0, 1, 1, 1, "1");
+        cout << "\n";
+    }
+}


### PR DESCRIPTION
## 문제 번호/제목
[0 만들기](https://www.acmicpc.net/problem/7490)
[민호와 강호](https://www.acmicpc.net/problem/11662)
[곱셈](https://www.acmicpc.net/problem/1629)
[연결 요소의 개수](https://www.acmicpc.net/problem/11724)
[영웅이는 2의 거듭 제곱을 좋아해! 영웅이는 2의 거듭 제곱을 좋아해!](https://www.acmicpc.net/problem/20153)
## 코드 설명
### [0 만들기](https://www.acmicpc.net/problem/7490)
1부터 N까지의 수를 오름차순으로 쓴 수열을 가지고 결과가 0이 되는 모든 수식을 찾는 프로그램을 작성하는 것이 문제이다.
연산의 종류는 3가지 (공백, 덧셈, 뺄셈)이고 전체 케이스는 3^10으로 완전탐색을 사용하여 문제 해결을 했다.
dfs 함수를 만들어 함수 내부에서 모든 연산의 종류를 시도했다.

문자열 다루는 능력이 핵심인거같다. (혹은 dfs함수의 parameter 설정하는 능력?)

### [민호와 강호](https://www.acmicpc.net/problem/11662)
민호와 강호가 가장 가까워지는 순간을 찾는 문제이다. 
pair 자료구조를 사용해 p%일때 강호와 민호의 x, y좌표를 표시하는 자료구조를 커스텀했다.
가장 가까워지는 순간은 삼분 탐색을해서 찾아줬다.
그리고 직선 거리라 유클리드 거리를 각각 구해서 최소값을 구했다.

### [곱셈](https://www.acmicpc.net/problem/1629)
단순한 곱셈 문제인데, 이건 곱셈의 값이 지나치게 커진다. 즉 모듈러 연산을 사용해서 효율적인 계산을 할 수 잇는지 물어보는 문제인거 같다.
또한 분할 정복 알고리즘을 사용해 시간복잡도를 log 시간대로 줄여줬다.

### [연결 요소의 개수](https://www.acmicpc.net/problem/11724)
알고리즘 시간에 배운 connected component를 구하는 문제.
2차원 배열을 사용해 edge를 표현하고 반복문을 통해 아직 방문하지 않은 요소가 있다면 count해주고 dfs로 연결 요소를 다 돌아본뒤 다시 반복문으로 돌아오는 식으로 진행했다.

### [영웅이는 2의 거듭 제곱을 좋아해! 영웅이는 2의 거듭 제곱을 좋아해!](https://www.acmicpc.net/problem/20153)
문제을 읽어보면... 자연수 한개 지우고 영웅이의 표현법으로 나타내고 2^x항을 홀수 개 포함하면 더하고, 짝수개면 제외 -> xor 연산과 동일

일단 입력값을 배열에 저장하면서 모두 xor 계산을 한다.
그 이후 모두 xor 계산한 값과 배열의 각 요소에 대해 xor한 값(xor 짝수 연산시 그 값 제거)을 비교해 최대값을 찾아준다.

# 질문 환영
## Reference



