### PR TITLE
250223/김영환

### DIFF
--- a/YOUNGHWAN/백준/1024_수열의_합.cpp
+++ b/YOUNGHWAN/백준/1024_수열의_합.cpp
@@ -1,0 +1,29 @@
+#include <bits/stdc++.h>
+using namespace std;
+int N, L, t;
+int sum(int n)
+{
+    return n * (n + 1) / 2;
+}
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> N >> L;
+    for (int i = L; i <= 100; i++)
+    {
+        int x = sum(i - 1);
+        if ((N - x) / i >= 0 && (N - x) % i == 0)
+        {
+            t = (N - x) / i;
+            for (int j = t; j < t + i; j++)
+            {
+                cout << j << " ";
+            }
+            cout << "\n";
+            return 0;
+        }
+    }
+
+    cout << -1;
+}

--- a/YOUNGHWAN/백준/1912_연속합.cpp
+++ b/YOUNGHWAN/백준/1912_연속합.cpp
@@ -1,0 +1,33 @@
+#include <bits/stdc++.h>
+#define MAX 1000000
+using namespace std;
+int k, ret;
+int arr[MAX], dp[MAX];
+int Max(int a, int b)
+{
+    if (a > b)
+    {
+        return a;
+    }
+    return b;
+}
+int main()
+{
+    ios::sync_with_stdio(false);
+    cin.tie(0);
+    cout.tie(0);
+    ret = -1004;
+    cin >> k;
+    for (int i = 1; i <= k; i++)
+    {
+        cin >> arr[i];
+    }
+    dp[1] = arr[1];
+    ret = dp[1];
+    for (int i = 2; i <= k; i++)
+    {
+        dp[i] = Max(arr[i], dp[i - 1] + arr[i]);
+        ret = Max(ret, dp[i]);
+    }
+    cout << ret;
+}

--- a/YOUNGHWAN/프로그래머스/내적.cpp
+++ b/YOUNGHWAN/프로그래머스/내적.cpp
@@ -1,0 +1,15 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int solution(vector<int> a, vector<int> b)
+{
+    int answer = 1234567890;
+    long long sum = 0;
+    for (int i = 0; i < a.size(); i++)
+    {
+        sum += (long long)a[i] * b[i];
+    }
+    answer = (int)sum;
+    return answer;
+}

--- a/YOUNGHWAN/프로그래머스/부족한_금액_계산하기.cpp
+++ b/YOUNGHWAN/프로그래머스/부족한_금액_계산하기.cpp
@@ -1,0 +1,10 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+long long solution(int price, int money, int count)
+{
+    long long answer = -1;
+    long long totalPrice = (long long)(price + (price * count)) * count / 2;
+    answer = totalPrice - money;
+    return answer > 0 ? answer : 0;
+}

--- a/YOUNGHWAN/프로그래머스/연속된_부분_수열의_합.cpp
+++ b/YOUNGHWAN/프로그래머스/연속된_부분_수열의_합.cpp
@@ -1,0 +1,36 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+vector<int> solution(vector<int> sequence, int k)
+{
+    int sPoint = 0;
+    int ePoint = 0;
+    int currentSum = 0;
+    vector<int> answer = {-1, -1};
+    int minLength = INT_MAX;
+
+    while (ePoint < sequence.size())
+    {
+        currentSum += sequence[ePoint];
+
+        while (currentSum > k && sPoint <= ePoint)
+        {
+            currentSum -= sequence[sPoint];
+            sPoint++;
+        }
+
+        if (currentSum == k)
+        {
+            if (ePoint - sPoint < minLength)
+            {
+                minLength = ePoint - sPoint;
+                answer = {sPoint, ePoint};
+            }
+        }
+
+        ePoint++;
+    }
+
+    return answer;
+}


### PR DESCRIPTION
## 문제 번호/제목
[연속된 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/178870)
[부족한 금액 계산하기](https://school.programmers.co.kr/learn/courses/30/lessons/82612)
[내적](https://school.programmers.co.kr/learn/courses/30/lessons/70128)
[연속합](https://www.acmicpc.net/problem/1912)
[수열의 합](https://www.acmicpc.net/problem/1024)
## 코드 설명
## [연속된 부분 수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/178870)
슬라이딩 윈도우를 사용해서 구했고 각 순회마다 총합과 목표 값을 비교하여 포인터를 조절했다.

## [부족한 금액 계산하기](https://school.programmers.co.kr/learn/courses/30/lessons/82612)
문제를 보면 공차와 첫째항이 같은 등차수열을 생각할 수 있다. 가우스의 등차수열 합 공식을 사용해서 풀었다.

## [내적](https://school.programmers.co.kr/learn/courses/30/lessons/70128)
그냥 벡터 내적이다.

## [연속합](https://www.acmicpc.net/problem/1912)
dp 알고리즘을 사용해서 풀었다. 그냥 값이 큰걸 판단해서 값 수정하는 식으로 사용했다.

## [수열의 합](https://www.acmicpc.net/problem/1024)
그냥 조건에 맞게 L부터 하나씩 가우스 합 구하고 조건에 해당하는거 순차적으로 출력하면 된다.
## Reference



