### PR TITLE
250223/김지나

### DIFF
--- a/Jina/1012_유기농 배추.py
+++ b/Jina/1012_유기농 배추.py
@@ -1,0 +1,40 @@
+import sys
+sys.setrecursionlimit(10000) # 재귀 깊이 설정
+
+def dfs(x, y):
+  if x <= -1 or x >= N or y<= -1 or y>= M:
+    return False
+
+  if graph[x][y] == 1:
+    graph[x][y] = 0
+
+    for i in range(4):
+      dfs(x + dx[i], y+dy[i])
+
+    return True
+  return False
+
+
+T = int(sys.stdin.readline()) 
+
+dx = [-1, 1, 0, 0] # 상하좌우 이동
+dy = [0, 0, -1, 1]
+
+answer = []
+
+for _ in range(T):
+  M, N, K = list(map(int, sys.stdin.readline().split()))  
+
+  graph = [[0]*M for _ in range(N)]
+
+  for _ in range(K):
+    x, y = map(int, input().split())
+    graph[y][x] = 1
+
+  cnt = 0
+  for i in range(N):
+    for j in range(M):
+      if dfs(i, j):
+        cnt +=1
+
+  print(cnt)

--- a/Jina/1260_DFS와 BFS.py
+++ b/Jina/1260_DFS와 BFS.py
@@ -1,0 +1,42 @@
+import sys
+
+def dfs(idx) : 
+    global visited
+    visited[idx] = 1
+    print(idx, end=' ')
+    for next in range(1, N + 1):
+        if not visited[next] and graph[idx][next]:
+            dfs(next)
+
+def bfs():
+    global q, visited
+    while q:
+        cur = q.pop(0)
+        print(cur, end = ' ')
+        for next in range(1, N + 1):
+            if not visited[next] and graph[cur][next]:
+                visited[next] = 1
+                q.append(next)
+                
+
+input = sys.stdin.readline
+N, M, V = map(int, input().split())
+
+graph = [[0] * (N + 1) for _ in range(N + 1)]
+visited = [0] * (N + 1)
+
+# 그래프 정보 입력
+for _ in range(M):
+    a, b = map(int, input().split())
+    graph[a][b] = 1
+    graph[b][a] = 1
+
+# dfs
+dfs(V)
+print()
+
+# bfs
+visited = [0] * (N + 1)
+q = [V]
+visited[V] = 1
+bfs()

--- a/Jina/2178_미로 탐색.py
+++ b/Jina/2178_미로 탐색.py
@@ -1,0 +1,32 @@
+from collections import deque
+import sys
+
+# BFS
+def bfs():
+    while queue:
+        x, y = queue.popleft()
+        for i in range(4):
+            next_x, next_y = x + dx[i], y + dy[i]
+            # 미로의 범위 안인지 확인
+            if 0 <= next_x < N and 0 <= next_y < M: 
+                
+                if graph[next_x][next_y] == 1:
+                    queue.append((next_x, next_y))
+                    graph[next_x][next_y] = graph[x][y] + 1
+    return graph[N - 1][M - 1]
+
+input = sys.stdin.readline
+N, M = map(int, input().split())
+
+# 2차원 리스트 생성
+graph = [list(map(int, ' '.join(input().split()))) for _ in range(N)]
+
+queue = deque([(0, 0)])
+
+# 이동 표현 (위, 아래, 오른쪽, 왼쪽)
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+cnt = 0
+
+print(bfs())
+

--- a/Jina/2606_바이러스.py
+++ b/Jina/2606_바이러스.py
@@ -1,0 +1,28 @@
+import sys
+from collections import deque
+
+N = int(sys.stdin.readline())
+M = int(sys.stdin.readline())
+
+net = [[] for _ in range(N+1)]
+for _ in range(M):
+    a, b = map(int, sys.stdin.readline().split())
+    net[a].append(b)
+    net[b].append(a)
+
+def bfs():
+    q = deque()
+    count = 0 # 감염된 컴퓨터 수
+    q.append(1) # 1번 컴퓨터로부터 시작
+    visited[1] = True # 1번 컴퓨터 감염완료
+    while q:
+        cur = q.popleft()
+        for i, val in enumerate(net[cur]): # 감염된 컴퓨터로부터 연결된 컴퓨터들에서
+            if visited[val]==False: # 감염되지 않았다면
+                q.append(val) # 감염리스트에 추가
+                visited[val] = True # 감염완료
+                count += 1 # 감염된 컴퓨터 수 1 증가
+    print(count) # 모두 감염되었을 때 출력
+
+visited = [False for _ in range(N+1)]
+bfs()

--- a/Jina/2667_단지번호붙이기.py
+++ b/Jina/2667_단지번호붙이기.py
@@ -1,0 +1,45 @@
+import sys
+from collections import deque
+
+def dfs(x, y):
+    global count
+
+    if x < 0 or x >= N or y < 0 or y >= N:
+        return
+
+    if graph[x][y] == 1:
+        count += 1
+        graph[x][y] = 0
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            dfs(nx, ny)
+
+input = sys.stdin.readline
+
+N = int(input())
+
+graph = []  # 입력받을 그래프를 담을 리스트 선언
+result = []  # 결과를 담을 리스트 선언
+count = 0
+
+for _ in range(N):
+    graph.append(list(map(int, input().rstrip())))
+
+# 한 점을 기준으로 (위 아래 오른쪽 왼쪽) 으로 한칸씩 이동할 좌표 설정
+dx = [0, 0, 1, -1]
+dy = [1, -1, 0, 0]
+
+# 그래프의 원소가 1일때만 dfs로 집을 방문한다.
+for i in range(N):
+    for j in range(N):
+        if graph[i][j] == 1:
+            dfs(i, j)
+            result.append(count)
+            count = 0
+
+result.sort()  # 오름차순으로 정렬
+
+print(len(result))  # 총 단지수 출력
+for k in result:  # 각 단지마다 집의 수 출력
+    print(k)


### PR DESCRIPTION
## 문제 번호/제목

[DFS와 BFS](https://www.acmicpc.net/problem/1260)

[미로 탐색](https://www.acmicpc.net/problem/2178)

[바이러스](https://www.acmicpc.net/problem/2606)

[단지번호붙이기](https://www.acmicpc.net/problem/2667)

[유기농 배추](https://www.acmicpc.net/problem/1012)

## 코드 설명

[DFS와 BFS](https://www.acmicpc.net/problem/1260)

이번주는 그래프 알고리즘에 대해 공부한 후, 관련 문제들을 풀어보았다. 

우선 그래프를 초기화한 후, 방문 여부를 저장하는 visited 리스트를 만들었다. 양방향 그래프이므로 graph[a][b] = 1 뿐만 아니라 graph[b][a] = 1도 설정했다. dfs 함수에서는 정점을 방문하면 visited 리스트에 해당 정점에 1로 표시한 후, 출력했다. 방문하지 않은 정점이고 현재 정점에 연결되어 있다면 dfs(next)를 호출하여 재귀적으로 탐색하도록 했다.

bfs 함수에서는 큐를 사용하여 방문할 정점을 저장했다. 만약 방문하지 않은 정점이라면 visited 리스트를 1로 업데이트한 후 q.append(next)로 큐에 추가했다. bfs 함수를 실행하기 전에 visited 리스트를 초기화 한 후, 시작 정점을 큐에 넣은 후 함수를 실행했다.

[미로 탐색](https://www.acmicpc.net/problem/2178)

재귀적 특징을 이용하여 모든 경우를 하나씩 탐색하는 dfs와 달리, 이 문제는 미로를 탈출할 수 있는 최단 거리를 찾는 문제였기에 bfs를 이용했다. 먼저, graph로 미로를 저장할 수 있는 2차원 리스트를 만들었다. 위, 아래, 왼쪽, 오른쪽을 이동할 수 있도록 4가지 방향을 만들었다.
이때,  `if 0 <= next_x < N and 0 <= next_y < M: ` 를 통해 미로의 범위 안인지 확인할 수 있도록 했고, 이동이 가능하다면 큐에 추가 후 거리를 업데이트 했다. 새롭게 방문한 위치는 기존 위치의 값 + 1로 업데이트한다. 

[바이러스](https://www.acmicpc.net/problem/2606)

1번 컴퓨터가 감염되었을 때, 연결된 다른 컴퓨터가 몇 대 감염되는지 출력하는 문제다. 가까운 노드부터 차례대로 탐색하기에 bfs를 사용했다. 
net라는 그래프를 만들어주었고, 무방향 즉 양방향이기에 net[a]와 net[b]에도 추가해주었다. 
1번 컴퓨터부터 시작하기에 큐에 1번 컴퓨터를 넣고 시작했다. 방문하지 않은 컴퓨터라면 감염시키고 count를 증가시킨다. 
이를 큐가 빌 때까지 반복하고 감염된 컴퓨터 개수를 출력했다.

[단지번호붙이기](https://www.acmicpc.net/problem/2667)

1이 표시된 영역을 연결된 단지로 보고, 각 단지에 포함된 집의 개수를 출력하는 문제다. 한 단지를 모두 탐색하기에 dfs 방식을 사용했다. 
리스트 전체를 돌면서 집이 있는 경우(1인 경우)에 dfs 탐색을 시작한다. dfs가 끝나면 한 단지의 집 개수가 result 리스트에 저장되고, 다시 새로운 단지를 탐색하기 위해 count를 0으로 초기화 한다.
각 단지 내 집의 개수를 정렬하고 출력했다.

[유기농 배추](https://www.acmicpc.net/problem/1012)

한 배추밭을 완전히 탐색하고 벌레를 배정하기 위해 dfs를 사용했다. 먼저 dfs 함수에서는 상하좌우를 탐색하여 연결된 배추를 찾아내고 더이상 연결된 배추가 없을 때 탐색을 종료한다. 배추밭 그래프를 초기화하고 배추의 위치를 리스트에 저장한다. 
이때 문제에서 주어지는 좌표는 (열, 행) 좌표이기에 (행, 열)로 바꾸어서 
`graph[y][x] = 1` 로 저장해야 한다. 이 부분을 몰랐어서 레퍼런스를 참고했다. 

## Reference



