### PR TITLE
250223/한승훈

### DIFF
--- a/SeungHoon/10주차/11053_SeungHoon.py
+++ b/SeungHoon/10주차/11053_SeungHoon.py
@@ -1,0 +1,21 @@
+# [BOJ] 가장 긴 부분수열 / Silver 2 / 40m
+
+N = int(input())
+
+arr = list(map(int,input().split()))
+dp = [1] * N
+
+for i in range(1, N):
+  for j in range(i):
+    if(arr[j] < arr[i]):
+      dp[i] = max(dp[i], dp[j] + 1)
+      
+print(max(dp))
+
+# dp배열을 1로 초기화(연속되지 않는 수열의 길이는 1이기 때문)
+# 첫번째 반복문이 뒤의 수
+# 두번째 반복문이 그 이전의 수들
+# 이전의 수(j)가 이후의 수(i)보다 작으면 현재 dp[i]의 값과 dp[j]+1을 비교해 큰 값을 dp에 배치
+# 이후 dp 배열의 최댓값 출력
+
+# https://it-adventures.tistory.com/109

--- a/SeungHoon/10주차/11055_SeungHoon.py
+++ b/SeungHoon/10주차/11055_SeungHoon.py
@@ -1,0 +1,22 @@
+# [BOJ] 가장 큰 증가하는 부분 수열 / Silver 2 / 20m
+N = int(input())
+
+A = list(map(int,input().split()))
+
+dp = [0] * N
+dp[0] = A[0]
+
+for i in range(N):
+  for j in range(i):
+    if(A[j] < A[i]):
+      dp[i] = max(dp[i], dp[j] + A[i])
+    else:
+      dp[i] = max(dp[i], A[i])
+      
+print(max(dp))
+
+# 11053번과 유사하다.
+# 합을 구해야하기 때문에 0으로 dp 배열을 초기화
+# 조건이 2개가 필요하다
+# 1.증가하는 부분수열이면 dp[i] = max(dp[i], dp[j] + A[i])로 값을 갱신
+# 그렇지 않다면 dp[i]와 dp[j]중 큰 값으로 갱신

--- a/SeungHoon/10주차/16395_SeungHoon.py
+++ b/SeungHoon/10주차/16395_SeungHoon.py
@@ -1,0 +1,25 @@
+# [BOJ] 파스칼의 삼각형 / Silver 5 / 30m
+n, k = map(int,input().split())
+
+up = 1
+down = 1
+count = 1
+
+for i in range(n - 1, 0, -1):
+  if(count == k):
+    break
+  up = up * i
+  count += 1
+
+
+for i in range(1, k):
+  down = down * i
+
+print(up // down)
+
+# 문제에서 이항계수를 출력하라는 힌트를 준다
+# 다만 C(n-1, k-1)이다
+# 조합(Combination) 계산을 응용하여
+# 분자는 n-1 ~ k까지 곱하고
+# 분모는 1 ~ K까지 곱한 후
+# 나눠준다.

--- a/SeungHoon/10주차/24497_SeungHoon.py
+++ b/SeungHoon/10주차/24497_SeungHoon.py
@@ -1,0 +1,10 @@
+# [BOJ] blobnom / Silver 4 / 30
+N = int(input())
+arr = list(map(int,input().split()))
+ans = max(arr)
+
+for i in range(1, N - 1):
+  if (min((arr[i - 1], arr[i + 1])) > 0):
+    ans = max((ans, arr[i] + min((arr[i - 1], arr[i + 1]))))
+    
+print(ans)

--- a/SeungHoon/10주차/4673_SeungHoon.py
+++ b/SeungHoon/10주차/4673_SeungHoon.py
@@ -1,0 +1,12 @@
+# [BOJ] 셀프 넘버 / Silver 5 / 45m
+nums = set(range(1,10001))
+arr = set()
+
+for i in range(1,10001):
+  for j in str(i):
+    i += int(j)
+  arr.add(i)
+  
+ans = sorted(nums - arr)
+for i in ans:
+  print(i)


### PR DESCRIPTION
## 문제 번호/제목
[24497/blobnom](https://www.acmicpc.net/problem/24498)
[4673/셀프 넘버](https://www.acmicpc.net/problem/4673)
[16395/파스칼의 삼각형](https://www.acmicpc.net/problem/16395)
[11055/가장 큰 증가하는 부분 수열](https://www.acmicpc.net/problem/11055)
[11053/가장 긴 부분 수열](https://www.acmicpc.net/problem/11053)

## 코드 설명
[24497/blobnom](https://www.acmicpc.net/problem/24498)
가장 큰 값을 ans에 따로 저장함
i를 기준으로 N-2까지 i-1. i+1을 참조하면서 둘 중 더 작은 값의 합을 계산
ans와 비교하여 더 큰 값으로 대체

[4673/셀프 넘버](https://www.acmicpc.net/problem/4673)
자연수 1~10000까지 있는 set을 생성
1~10000까지 반복문을 돌고
2중 반복문으로 입력되는 i를 문자열로 바꿔서 각 자릿수와 i를 더한 수를 arr에 입력
기존 set-생성된 수를 하여 결과를 출력

[16395/파스칼의 삼각형](https://www.acmicpc.net/problem/16395)
문제에서 이항계수를 출력하라는 힌트를 준다
다만 C(n-1, k-1)이다
조합(Combination) 계산을 응용하여
분자는 n-1 ~ k까지 곱하고
분모는 1 ~ K까지 곱한 후
나눠준다.

[11055/가장 큰 증가하는 부분 수열](https://www.acmicpc.net/problem/11055)
11053번과 유사하다.
합을 구해야하기 때문에 0으로 dp 배열을 초기화
조건이 2개가 필요하다
1.증가하는 부분수열이면 dp[i] = max(dp[i], dp[j] + A[i])로 값을 갱신
그렇지 않다면 dp[i]와 dp[j]중 큰 값으로 갱신

[11053/가장 긴 부분 수열](https://www.acmicpc.net/problem/11053)
dp배열을 1로 초기화(연속되지 않는 수열의 길이는 1이기 때문)
첫번째 반복문이 뒤의 수
두번째 반복문이 그 이전의 수들
이전의 수(j)가 이후의 수(i)보다 작으면 현재 dp[i]의 값과 dp[j]+1을 비교해 큰 값을 dp에 배치
이후 dp 배열의 최댓값 출력



## Reference
[11053/가장 긴 부분 수열](https://it-adventures.tistory.com/109)


