### PR TITLE
250302/김지나

### DIFF
--- a/Jina/11723_집합.py
+++ b/Jina/11723_집합.py
@@ -1,0 +1,36 @@
+import sys
+
+input = sys.stdin.readline
+
+m = int(input())
+s = set()
+
+for _ in range(m):
+  arr = list(input().split())
+  c = arr[0]
+
+  if c == 'add':
+    s.add(int(arr[1]))
+
+  elif c == 'remove':
+    try:
+      s.remove(int(arr[1]))
+    except:
+      pass
+
+  elif c == 'check':
+    if int(arr[1]) in s:
+        print(1)
+    else:
+      print(0)
+
+  elif c == 'toggle':
+    if int(arr[1]) in s:
+      s.remove(int(arr[1]))
+    else:
+      s.add(int(arr[1]))
+      
+  elif c == 'all':
+    s = set([i for i in range(1,21)])
+  else:
+    s = set()

--- a/Jina/1654_랜선 자르기.py
+++ b/Jina/1654_랜선 자르기.py
@@ -1,0 +1,23 @@
+import sys
+
+K, N = map(int, sys.stdin.readline().strip().split())
+
+lines = []
+for _ in range(K):
+  lines.append(int(sys.stdin.readline().strip()))
+
+start, end = 1, max(lines)
+
+while(start <= end):
+  mid = (start + end) // 2
+  line_cnt = 0
+
+  for line in lines:
+    line_cnt +=  line // mid
+    
+  if line_cnt >= N:
+    start = mid + 1
+  else:
+    end = mid - 1
+
+print(end)

--- a/Jina/18110_solved.ac.py
+++ b/Jina/18110_solved.ac.py
@@ -1,0 +1,22 @@
+import sys
+
+def roundUp(num):
+    if(num - int(num)) >= 0.5:
+        return int(num) + 1
+    else:
+        return int(num)
+
+n = int(sys.stdin.readline().rstrip())
+
+if n == 0:
+    print(0)
+else:
+    arr = []
+    
+    for i in range(n):
+        arr.append(int(sys.stdin.readline().rstrip()))
+        
+    arr.sort()
+    border = roundUp(n * 0.15)
+    
+    print(roundUp(sum(arr[border:n-border])/len(arr[border:n-border])))

--- a/Jina/1874_스택 수열.py
+++ b/Jina/1874_스택 수열.py
@@ -1,0 +1,32 @@
+import sys
+
+n = int(sys.stdin.readline().strip())
+
+result = []
+stack = []
+
+# 1~n 중에서 현재 가리키고 있는 값
+cur = 1
+
+for _ in range(n):
+  seq = int(sys.stdin.readline().strip())
+  
+  # seq <= cur 만족할 때까지 반복
+  # 즉, seq까지 스택에 저장
+  while cur <= seq:
+    stack.append(cur)
+    result.append('+')
+    cur += 1
+
+  # while문을 실행한 seq값이 stack에 마지막에 삽입된 값과 같으면 실행
+  if stack[-1] == seq:
+    stack.pop()
+    result.append('-')
+  # 불가능하면 NO 출력
+  else:
+    result.clear()			
+    result.append('NO')	
+    break					
+
+for answer in result:
+  print(answer)

--- a/Jina/2108_통계학.py
+++ b/Jina/2108_통계학.py
@@ -1,0 +1,42 @@
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+data = []
+
+_sum = 0
+count = dict()
+for _ in range(n):
+    x = int(input())
+    data.append(x)
+
+    _sum += x
+
+    if x not in count:
+        count[x] = 1
+    else:
+        count[x] += 1
+
+data.sort()
+
+# 산술평균
+print(round(_sum/n))
+
+# 중앙값
+print(data[n//2])
+
+# 최빈값
+freq = max(count.values())
+numbers = []
+for key, value in count.items():
+    if value == freq:
+        numbers.append(key)
+
+if len(numbers) == 1:
+    print(numbers[0])
+else:
+    print(sorted(numbers)[1])
+
+# 범위
+print(data[-1] - data[0])


### PR DESCRIPTION
## 문제 번호/제목

[스택 수열](https://www.acmicpc.net/problem/1874)

[solved.ac](https://www.acmicpc.net/problem/18110)

[랜선 자르기](https://www.acmicpc.net/problem/1654)

[통계학](https://www.acmicpc.net/problem/2108)

[집합](https://www.acmicpc.net/problem/11723)

## 코드 설명

[스택 수열](https://www.acmicpc.net/problem/1874)

간단한 스택 문제라고 생각했는데 조금 오래걸렸다. 

1. 수열 중 하나의 정수 seq를 입력받으면 cur부터 seq까지 stack에 삽입
2. stack에 마지막에 삽입된 값이 seq와 같으면 stack에서 pop()하고, 출력할 결과 리스트인 result에 -를 삽입
3. stack에 마지막에 삽입된 값이 seq와 같지 않다면 수열을 출력하는 게 불가능한 경우이므로 지금까지 저장된 결과 리스트인 result를 초기화하고 NO만 삽입한 후 for문에서 break
4. 결과를 출력하고 종료

[solved.ac](https://www.acmicpc.net/problem/18110)

이 문제를 해결할 때 파이썬에 내장되어 있는 round 함수를 쓰면 안된다.
python에서 round함수를 사용한 반올림은 사사오입의 원칙을 따른다.
사사오입은 5에서 반올림 할때, 앞자리 숫자가 홀수면 올림, 짝수면 내림을 하는 것이다. 
따라서, 반올림 함수를 따로 만들어 문제를 풀었다.

[랜선 자르기](https://www.acmicpc.net/problem/1654)

이 문제는 이분 탐색을 이용하면 금방 풀 수 있는 문제였다. 이분탐색이 완료되면 N개를 만들 수 있는 랜선의 최대 길이인 end를 출력하면 된다.

[통계학](https://www.acmicpc.net/problem/2108)

입력되는 정수의 개수가 최대 500,000 이므로, 최대한 입력 받은 정수 리스트 순회를 줄이고자 했다. 

[집합](https://www.acmicpc.net/problem/11723)

메모리 제한이 있는 문제다.
처음에는 list를 이용해 문제를 풀었는데 메모리 초과로 실패했다. 연산의 수가 3,000,000까지 가능하므로 list에 담기에는 메모리가 부족하기에 set을 사용하여 풀었다.


## Reference



