### PR TITLE
250302 / 고건

### DIFF
--- a/Gun/11279_최대 힙.py
+++ b/Gun/11279_최대 힙.py
@@ -1,0 +1,19 @@
+import sys, heapq
+
+def solution():
+    input = sys.stdin.readline
+    n = int(input())
+    q = []
+    
+    for _ in range(n):
+        num = int(input())
+        if num == 0:
+            if not q:
+                print(0)
+            else:
+                print(-heapq.heappop(q))
+        else:
+            heapq.heappush(q, -num)
+        
+if __name__=='__main__': 
+    solution()

--- a/Gun/14425_문자열 집합.py
+++ b/Gun/14425_문자열 집합.py
@@ -1,0 +1,21 @@
+import sys
+
+def solution():
+    input = sys.stdin.readline
+    n, m = map(int, input().split())
+    a = set()
+    cnt = 0
+    
+    for _ in range(n):
+        a.add(input().strip()) 
+
+    for _ in range(m):
+        b = input().strip()
+        if b in a:
+            cnt += 1
+
+    print(cnt)
+
+
+if __name__=='__main__':
+    solution()

--- a/Gun/1927_최소 힙.py
+++ b/Gun/1927_최소 힙.py
@@ -1,0 +1,19 @@
+import sys, heapq
+
+def solution():
+    input = sys.stdin.readline
+    n = int(input())
+    q = []
+    
+    for _ in range(n):
+        num = int(input())
+        if num == 0:
+            if not q:
+                print(0)
+            else:
+                print(heapq.heappop(q))
+        else:
+            heapq.heappush(q, num)
+        
+if __name__=='__main__':
+    solution()

--- a/Gun/2075_N번째 큰 수.py
+++ b/Gun/2075_N번째 큰 수.py
@@ -1,0 +1,22 @@
+import sys, heapq
+
+def solution():
+    input = sys.stdin.readline
+    n = int(input())
+    q = []
+
+    for _ in range(n):
+        a = list(map(int, input().split()))
+        if not q:
+            for v in a:
+                heapq.heappush(q, v)
+        else:
+            for v in a:
+                if q[0] < v:
+                    heapq.heappush(q, v)
+                    heapq.heappop(q)
+    print(q[0])
+            
+
+if __name__=='__main__':
+    solution()

--- a/Gun/4358_생태학.py
+++ b/Gun/4358_생태학.py
@@ -1,0 +1,13 @@
+import sys
+from collections import Counter
+
+def solution():
+    tree = Counter(sys.stdin.read().split("\n"))
+    del tree[""]
+    l = sum(tree.values())
+    
+    for name in sorted(tree.keys()):
+            print("%s %.4f" % (name, tree[name] / l * 100))
+
+if __name__=='__main__':
+    solution()


### PR DESCRIPTION
## 문제 번호/제목

[문자열 집합](https://www.acmicpc.net/problem/14425)

[N번째 큰 수](https://www.acmicpc.net/problem/2075)

[생태학](https://www.acmicpc.net/problem/4358)

[최소 힙](https://www.acmicpc.net/problem/1927)

[최대 힙](https://www.acmicpc.net/problem/11279)


## 코드 설명


[문자열 집합](https://www.acmicpc.net/problem/14425)

문자열 집합 S에 포함된 횟수만큼 출력해주면 되는 문제이다. 간단히 str in S: 조건으로 검사해도 풀렸다..

[N번째 큰 수](https://www.acmicpc.net/problem/2075)

매우 적은 메모리를 가지고 N * N개의 수 중 N번째로 큰 수를 찾는 문제이다. 우선순위 큐를 이용하여 N개의 숫자를 입력받을 때, 입력값이 N번째로 큰 수(큐의 최솟값)보다 크면 그 수를 pop하고 입력값을 push하는 방식으로 큐의 길이를 N으로 유지했다. 

[생태학](https://www.acmicpc.net/problem/4358)

주어진 나무 종이 전체 종의 몇 퍼센트나 차지하는지 출력하는 문제이다. 출력하는 과정에서 파이썬의 round()함수의 문제를 알게 되었다. 

Round 함수는 1.000과 같이 0으로만 이루어진 숫자에 오류가 발생한다.

또한 round(1.5), round(2.5)는 둘 다 짝수 값인 2로 반올림한다는 문제가 있다.

따라서 print('{:.2f}'.format(1.000))  # 1.00 
와 같이 format 방식이나, “%s", f-string등의 방식을 사용할 수 있다. [참고](https://dogsavestheworld.tistory.com/m/entry/python-%EC%86%8C%EC%88%98-n%EC%A7%B8-%EC%9E%90%EB%A6%AC%EA%B9%8C%EC%A7%80-%EC%B6%9C%EB%A0%A5%ED%95%98%EA%B8%B0-round-format-f-string)

[최소 힙](https://www.acmicpc.net/problem/1927)

Heapq 자료구조를 사용하여 최소 힙을 구현하는 문제이다. 

[최대 힙](https://www.acmicpc.net/problem/11279)

마찬가지로 heapq를 이용해 최대 힙을 구현하는데, 최소 힙을 기준으로 만들어진 heapq에서 push, pop할 때 부호를 바꾸어 주면, 최대 힙처럼 이용할 수 있게 된다.

## Reference

[소수점 출력 어케함?](https://dogsavestheworld.tistory.com/m/entry/python-%EC%86%8C%EC%88%98-n%EC%A7%B8-%EC%9E%90%EB%A6%AC%EA%B9%8C%EC%A7%80-%EC%B6%9C%EB%A0%A5%ED%95%98%EA%B8%B0-round-format-f-string)

