### PR TITLE
250504/ 김영환

### DIFF
--- a/YOUNGHWAN/백준/1012_유기농배추.cpp
+++ b/YOUNGHWAN/백준/1012_유기농배추.cpp
@@ -1,0 +1,69 @@
+#include <bits/stdc++.h>
+using namespace std;
+#define X first
+#define Y second
+int T, M, N, K, x, y;
+int dx[4] = {0, -1, 0, 1};
+int dy[4] = {1, 0, -1, 0};
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> T;
+    // constraints
+    // 1<=M<=50 row
+    // 1<=N<=50 column
+    // 1<=K<=2500 cnt
+    while (T--)
+    {
+        int board[52][52] = {
+            0,
+        };
+        bool vis[52][52] = {
+            0,
+        };
+        cin >> M >> N >> K;
+        // 배추가 있는 위치 표시
+        while (K--)
+        {
+            cin >> x >> y;
+            board[x][y] = 1;
+        }
+        int cnt = 0;
+        for (int row = 0; row < M; row++)
+        {
+            for (int col = 0; col < N; col++)
+            {
+                if (vis[row][col] || !board[row][col])
+                {
+                    continue;
+                }
+                cnt++;
+                queue<pair<int, int>> Q;
+                vis[row][col] = 1;
+                Q.push({row, col});
+                while (!Q.empty())
+                {
+                    pair<int, int> cur = Q.front();
+                    Q.pop();
+                    for (int dir = 0; dir < 4; dir++)
+                    {
+                        int nx = cur.X + dx[dir];
+                        int ny = cur.Y + dy[dir];
+                        if (nx < 0 || nx >= M || ny < 0 || ny >= N)
+                        {
+                            continue;
+                        }
+                        if (vis[nx][ny] || board[nx][ny] != 1)
+                        {
+                            continue;
+                        }
+                        vis[nx][ny] = 1;
+                        Q.push({nx, ny});
+                    }
+                }
+            }
+        }
+        cout << cnt << "\n";
+    }
+}

--- a/YOUNGHWAN/백준/1074_Z.cpp
+++ b/YOUNGHWAN/백준/1074_Z.cpp
@@ -1,0 +1,26 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, r, c;
+int func(int n, int r, int c)
+{
+    if (n == 0)
+    {
+        return 0;
+    }
+    int half = 1 << (n - 1);
+    if (r < half && c < half)
+        return func(n - 1, r, c);
+    if (r < half && c >= half)
+        return half * half + func(n - 1, r, c - half);
+    if (r >= half && c < half)
+        return 2 * half * half + func(n - 1, r - half, c);
+    return 3 * half * half + func(n - 1, r - half, c - half);
+}
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> n >> r >> c;
+    cout << func(n, r, c);
+}

--- a/YOUNGHWAN/백준/13549_숨바꼭질_3.cpp
+++ b/YOUNGHWAN/백준/13549_숨바꼭질_3.cpp
@@ -1,0 +1,45 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, k;
+int dist[200002];
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    fill(dist, dist + 200000, -1);
+    // constraints
+    // 0 <= n <= 100_000
+    // 0 <= k <= 100_000
+    cin >> n >> k;
+
+    dist[n] = 0;
+    deque<int> Q;
+    Q.push_back(n);
+    while (!Q.empty())
+    {
+        int cur = Q.front();
+        Q.pop_front();
+        // 1초 후는 x-1 , x+1
+        // 0초 후는 2*x, x
+        if (2 * cur < 200000 && dist[2 * cur] == -1)
+        {
+            dist[2 * cur] = dist[cur];
+            Q.push_front(2 * cur);
+        }
+        for (int nxt : {cur - 1, cur + 1})
+        {
+            if (nxt < 0 || nxt >= 200000)
+            {
+                continue;
+            }
+            if (dist[nxt] != -1)
+            {
+                continue;
+            }
+            dist[nxt] = dist[cur] + 1;
+            Q.push_back(nxt);
+        }
+    }
+    cout << dist[k];
+}

--- a/YOUNGHWAN/백준/15888_정답은 이수근이야.cpp
+++ b/YOUNGHWAN/백준/15888_정답은 이수근이야.cpp
@@ -1,0 +1,33 @@
+#include <bits/stdc++.h>
+using namespace std;
+int A, B, C;
+const int p[6] = {2, 4, 8, 16, 32, 64};
+
+int main()
+{
+
+    cin >> A >> B >> C;
+
+    int r_cnt = 0, p_cnt = 0;
+    for (int x = -100; x <= 100; x++)
+    {
+        if (A * x * x + B * x + C == 0)
+        {
+            r_cnt++;
+            for (int i = 0; i < 6; i++)
+            {
+                if (x == p[i])
+                    p_cnt++;
+            }
+        }
+    }
+
+    if (r_cnt != 2)
+        cout << "둘다틀렸근";
+    else if (p_cnt == 2)
+        cout << "이수근";
+    else
+        cout << "정수근";
+
+    return 0;
+}

--- a/YOUNGHWAN/백준/1630_오민식.cpp
+++ b/YOUNGHWAN/백준/1630_오민식.cpp
@@ -1,0 +1,44 @@
+#include <bits/stdc++.h>
+using namespace std;
+int N;
+const long long moduler = 987654321;
+bool p_number[1000004];
+vector<int> p_numbers;
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+    // constraint : 0 < N < 1,000,000
+    // example 1 : 10 -> 2520(2^3 * 3^2 * 5* 7)
+    cin >> N;
+    // input보다 작은 소수 찾고, 가장 큰 소인수의 제곱수를 곱해주는거 
+    for (int i = 2; i <= N; i++)
+    {
+        for (int j = 2 * i; j <= N; j += i)
+        {
+            p_number[j] = 1;
+        }
+    }
+
+    for (int i = 2; i <= N; i++)
+    {
+        if (!p_number[i])
+        {
+            p_numbers.push_back(i);
+        }
+    }
+    long long res = 1;
+    for (auto p : p_numbers)
+    {
+        if (p > N)
+            break;
+        long long cur = p;
+        while (cur * p <= N)
+        {
+            cur *= p;
+        }
+        res = (res * cur) % moduler;
+    }
+    cout << res;
+}

--- a/YOUNGHWAN/백준/1697_숨바꼭질.cpp
+++ b/YOUNGHWAN/백준/1697_숨바꼭질.cpp
@@ -1,0 +1,38 @@
+#include <bits/stdc++.h>
+#define X first
+#define Y second
+using namespace std;
+int dist[100002];
+int n, k;
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    fill(dist, dist + 100001, -1);
+    // constraints
+    // 0 <= N <= 100_000
+    // 0 <= K <= 100_000
+    cin >> n >> k;
+    dist[n] = 0;
+    queue<int> Q;
+    Q.push(n);
+    while (dist[k] == -1)
+    {
+        int cur = Q.front();
+        Q.pop();
+        for (int nxt : {cur - 1, cur + 1, 2 * cur})
+        {
+            if (nxt < 0 || nxt > 100000)
+            {
+                continue;
+            }
+            if (dist[nxt] != -1)
+            {
+                continue;
+            }
+            dist[nxt] = dist[cur] + 1;
+            Q.push(nxt);
+        }
+    }
+    cout << dist[k];
+}

--- a/YOUNGHWAN/백준/17128_소가 정보섬에 올라온 이유.cpp
+++ b/YOUNGHWAN/백준/17128_소가 정보섬에 올라온 이유.cpp
@@ -1,0 +1,52 @@
+#include <bits/stdc++.h>
+using namespace std;
+int N, Q;
+
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    cin >> N >> Q;
+
+    vector<int> A(N);
+    vector<int> v(Q);
+
+    for (int i = 0; i < N; i++)
+    {
+        cin >> A[i];
+    }
+    for (int i = 0; i < Q; i++)
+    {
+        cin >> v[i];
+    }
+
+    long long curSum = 0;
+    vector<long long> sum(N, 1);
+
+    for (int i = 0; i < N; i++)
+    {
+        sum[i] = 1;
+        for (int j = 0; j < 4; j++)
+        {
+            sum[i] *= A[(i + j) % N]; // 원형 배열 처리
+        }
+        curSum += sum[i];
+    }
+
+    for (int i = 0; i < Q; i++)
+    {
+        int k = v[i] - 1;
+
+        for (int j = 0; j < 4; j++)
+        {
+            int idx = (k - j + N) % N;
+            curSum -= sum[idx];
+            sum[idx] *= -1;
+            curSum += sum[idx];
+        }
+        cout << curSum << "\n";
+    }
+
+    return 0;
+}

--- a/YOUNGHWAN/백준/1806_부분합.cpp
+++ b/YOUNGHWAN/백준/1806_부분합.cpp
@@ -1,0 +1,38 @@
+#include <bits/stdc++.h>
+using namespace std;
+int n, s;
+int a[100005];
+long long psum[100005];
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> n >> s;
+    psum[0] = 0;
+    // array init
+    for (int i = 1; i <= n; i++)
+    {
+        cin >> a[i];
+        psum[i] = psum[i - 1] + a[i];
+    }
+
+    // two pointer algorithm
+    int cnt = n + 1;
+    int end = 1;
+    for (int start = 1; start <= n; start++)
+    {
+        while (psum[end] - psum[start - 1] < s && end <= n)
+        {
+            end++;
+        }
+        if (cnt > end - start && psum[end] - psum[start - 1] >= s)
+        {
+            cnt = end - start + 1;
+        }
+    }
+    if (cnt == n + 1)
+    {
+        cnt = 0;
+    }
+    cout << cnt;
+}

--- a/YOUNGHWAN/백준/1926_그림.cpp
+++ b/YOUNGHWAN/백준/1926_그림.cpp
@@ -1,0 +1,67 @@
+#include <bits/stdc++.h>
+#define X first
+#define Y second
+using namespace std;
+int board[501][501] = {
+    0,
+};
+bool vis[501][501] = {
+    0,
+};
+int n, m;                  // n = 행, m = 열
+int dx[4] = {1, 0, -1, 0}; // 행의 이동 좌표 오 위 왼 아
+int dy[4] = {0, -1, 0, 1}; // 열의 이동 좌표 오 위 왼 아
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    // constraints
+    // 1 <= n <= 500
+    // 1 <= m <= 500
+    cin >> n >> m;
+    for (int x = 0; x < n; x++)
+    {
+        for (int y = 0; y < m; y++)
+        {
+            cin >> board[x][y];
+        }
+    }
+
+    int cnt = 0, curMax = 0; // cnt = 그림의 개수, curMax = 넓이의 최대값
+    for (int x = 0; x < n; x++)
+    {
+        for (int y = 0; y < m; y++)
+        {
+            if (vis[x][y] || !board[x][y])
+            {
+                continue;
+            }
+            cnt++;
+            queue<pair<int, int>> Q;
+            vis[x][y] = 1;
+            Q.push({x, y});
+            int mx = 0;
+            while (!Q.empty())
+            {
+                mx++;
+                pair<int, int> cur = Q.front();
+                Q.pop();
+                for (int dir = 0; dir < 4; dir++)
+                {
+                    int nx = cur.X + dx[dir];
+                    int ny = cur.Y + dy[dir];
+                    if (nx < 0 || nx >= n || ny < 0 || ny >= m)
+                        continue;
+                    if (vis[nx][ny] || board[nx][ny] != 1)
+                        continue;
+                    vis[nx][ny] = 1;
+                    Q.push({nx, ny});
+                }
+            }
+            curMax = max(mx, curMax);
+        }
+    }
+    cout << cnt << "\n"
+         << curMax;
+}

--- a/YOUNGHWAN/백준/2468_안전영역.cpp
+++ b/YOUNGHWAN/백준/2468_안전영역.cpp
@@ -1,0 +1,78 @@
+#include <bits/stdc++.h>
+#define X first
+#define Y second
+using namespace std;
+int N;
+int mat[102][102];
+bool vis[102][102];
+int dx[4] = {0, 0, 1, -1};
+int dy[4] = {1, -1, 0, 0};
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    // constraints
+    //  2 <= N <= 100 (integer)
+    cin >> N;
+    for (int i = 0; i < N; i++)
+    {
+        fill(mat[i], mat[i] + N, 0);
+        fill(vis[i], vis[i] + N, 0);
+    }
+
+    for (int x = 0; x < N; x++)
+    {
+        for (int y = 0; y < N; y++)
+        {
+            cin >> mat[x][y];
+        }
+    }
+    int curMax = 0;
+    for (int h = 0; h < 101; h++)
+    {
+        queue<pair<int, int>> Q;
+        // 아래는 visit 배열 초기화
+        for (int i = 0; i < N; i++)
+        {
+            fill(vis[i], vis[i] + N, 0);
+        }
+        int cnt = 0;
+        // 각 원소 별로 h에 비해 원소값 비교
+        for (int x = 0; x < N; x++)
+        {
+            for (int y = 0; y < N; y++)
+            {
+                if (mat[x][y] > h && !vis[x][y])
+                {
+                    // 높이(원소 값)가 h보다 높고, 아직 가보지 않은 지역에 대해 BFS를 진행한다.
+                    Q.push({x, y});
+                    vis[x][y] = 1;
+                    while (!Q.empty())
+                    {
+                        auto cur =Q.front();
+                        Q.pop();
+                        for (int dir = 0; dir < 4; dir++)
+                        {
+                            int nx = cur.X + dx[dir];
+                            int ny = cur.Y + dy[dir];
+
+                            if (nx < 0 || nx >= N || ny < 0 || ny >= N)
+                            {
+                                continue;
+                            }
+                            if (vis[nx][ny] || mat[nx][ny] <= h)
+                            {
+                                continue;
+                            }
+                            vis[nx][ny] = 1;
+                            Q.push({nx, ny});
+                        }
+                    }
+                    cnt++;
+                }
+            }
+        }
+        curMax = max(cnt, curMax);
+    }
+    cout << curMax;
+}

--- a/YOUNGHWAN/백준/2538_영역_구하기.cpp
+++ b/YOUNGHWAN/백준/2538_영역_구하기.cpp
@@ -1,0 +1,82 @@
+#include <bits/stdc++.h>
+#define X first
+#define Y second
+
+using namespace std;
+int board[102][102] = {
+    0,
+};
+bool vis[102][102] = {
+    0,
+};
+int M, N, K, lx, ly, rx, ry;
+int dx[4] = {0, -1, 0, 1};
+int dy[4] = {1, 0, -1, 0};
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    // constraints
+    // 1<= M <=100
+    // 1<= N <=100
+    // 1<= K <=100
+    cin >> M >> N >> K;
+    while (K--)
+    {
+        cin >> lx >> ly >> rx >> ry;
+        for (int i = ly; i < ry; i++)
+        {
+            for (int j = lx; j < rx; j++)
+            {
+                board[i][j] = 1;
+            }
+        }
+    }
+    int cnt = 0;
+    vector<int> sizes = {};
+    for (int x = 0; x < M; x++)
+    {
+        for (int y = 0; y < N; y++)
+        {
+            if (vis[x][y] || board[x][y] != 0)
+            {
+                continue;
+            }
+            cnt++;
+            int sz = 0;
+            queue<pair<int, int>> Q;
+
+            vis[x][y] = 1;
+            Q.push({x, y});
+            while (!Q.empty())
+            {
+                sz++;
+                pair<int, int> cur = Q.front();
+                Q.pop();
+                for (int dir = 0; dir < 4; dir++)
+                {
+                    int nx = cur.X + dx[dir];
+                    int ny = cur.Y + dy[dir];
+                    if (nx < 0 || nx >= M || ny < 0 || ny >= N)
+                    {
+                        continue;
+                    }
+                    if (vis[nx][ny] || board[nx][ny] > 0)
+                    {
+                        continue;
+                    }
+                    vis[nx][ny] = 1;
+                    Q.push({nx, ny});
+                }
+            }
+            sizes.push_back(sz);
+        }
+    }
+    cout << cnt << "\n";
+    sort(sizes.begin(), sizes.end());
+    for (int i = 0; i < cnt; i++)
+    {
+        cout << sizes[i] << " ";
+    }
+}

--- a/YOUNGHWAN/백준/4233_가짜소수.cpp
+++ b/YOUNGHWAN/백준/4233_가짜소수.cpp
@@ -1,0 +1,73 @@
+#include <bits/stdc++.h>
+using namespace std;
+int a, p;
+bool isPrime(int p)
+{
+    if (p <= 1)
+    {
+        return 0;
+    }
+    if (p == 2 || p == 3)
+    {
+        return 1;
+    }
+    if (p % 2 == 0 || p % 3 == 0)
+    {
+        return 0;
+    }
+    for (int i = 5; i * i <= p; i += 6)
+    {
+        if (p % i == 0 || p % (i + 2) == 0)
+        {
+            return 0;
+        }
+    }
+    return 1;
+}
+int main()
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cout.tie(0);
+    // problem
+    // p가 소수일 떼, a^p == a (mod p)가 성립
+    // 가짜 소수 : a^p = a(mod p) 성립. but, p가 소수는 아님.
+
+    // constraints
+    // * 2 < p <= 1,000,000,000
+    // * 1 < a < p
+    while (true)
+    {
+        cin >> p >> a;
+
+        if (p == 0 && a == 0)
+        {
+            break;
+        }
+        if (isPrime(p))
+        {
+            cout << "no" << "\n";
+            continue;
+        }
+        long long curRes = 1;
+        long long exp = p;
+        long long base = a;
+        while (exp > 0)
+        {
+            if (exp % 2 == 1)
+            {
+                curRes = (curRes * base) % p;
+            }
+            base = (base * base) % p;
+            exp /= 2;
+        }
+        // cout << curRes % p << " " << p << isPrime(p) << " " << "\n";
+        if (curRes == a && !isPrime(p))
+        {
+            cout << "yes" << "\n";
+            continue;
+        }
+        cout << "no" << "\n";
+    }
+    return 0;
+}

--- a/YOUNGHWAN/백준/5427_불.cpp
+++ b/YOUNGHWAN/백준/5427_불.cpp
@@ -1,0 +1,111 @@
+#include <bits/stdc++.h>
+#define X first
+#define Y second
+using namespace std;
+int dx[4] = {0, -1, 0, 1};
+int dy[4] = {1, 0, -1, 0};
+int board[1002][1002];
+int viS[1002][1002];
+int viF[1002][1002];
+int T, w, h;
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+    cin >> T; // test case
+    while (T--)
+    {
+        // constraints
+        //  1 <= w, h <= 1_000
+        cin >> w >> h;
+        for (int i = 0; i < h; i++)
+        {
+            fill(viF[i], viF[i] + w, 0);
+            fill(viS[i], viS[i] + w, 0);
+        }
+
+        queue<pair<int, int>> Qs = {}, Qf = {};
+        for (int x = 0; x < h; x++)
+        {
+            for (int y = 0; y < w; y++)
+            {
+                board[x][y] = 0;
+                char c;
+                cin >> c;
+                if (c == '#')
+                {
+                    board[x][y] = -1;
+                }
+                else
+                {
+                    if (c == '@')
+                    {
+                        Qs.push({x, y});
+                        viS[x][y] = 1;
+                    }
+                    if (c == '*')
+                    {
+                        Qf.push({x, y});
+                        viF[x][y] = 1;
+                    }
+                }
+            }
+        }
+        // 불이 옮겨 붙는 지역을 먼저 BFS를 통해 지정.
+        while (!Qf.empty())
+        {
+            auto cur = Qf.front();
+            Qf.pop();
+            for (int i = 0; i < 4; i++)
+            {
+                int nx = cur.X + dx[i];
+                int ny = cur.Y + dy[i];
+                if (nx < 0 || nx >= h || ny < 0 || ny >= w)
+                {
+                    continue;
+                }
+                if (board[nx][ny] == -1)
+                {
+                    continue;
+                }
+                if (viF[nx][ny])
+                {
+                    continue;
+                }
+                viF[nx][ny] = viF[cur.X][cur.Y] + 1;
+                Qf.push({nx, ny});
+            }
+        }
+        bool escape = 0;
+        // 불이 옮겨 붙은것을 기준으로 user의 이동 환경을 BFS
+        while (!Qs.empty() && !escape)
+        {
+            auto curS = Qs.front();
+            Qs.pop();
+            for (int dir = 0; dir < 4; dir++)
+            {
+                int nx = curS.X + dx[dir];
+                int ny = curS.Y + dy[dir];
+                if (nx < 0 || h <= nx || ny < 0 || w <= ny)
+                {
+                    cout << viS[curS.X][curS.Y] << '\n';
+                    escape = true;
+                    break;
+                }
+                if (board[nx][ny] == -1)
+                    continue;
+                if (viS[nx][ny])
+                    continue;
+                // 이 조건은 문제에서 제시한 조건으로 불이 붙은 지역의 값을 이용하여 지나 갈 수 잇는지 없는지 확인.
+                if (viF[nx][ny] != 0 && viF[nx][ny] <= viS[curS.X][curS.Y] + 1)
+                    continue;
+                viS[nx][ny] = viS[curS.X][curS.Y] + 1;
+                Qs.push({nx, ny});
+            }
+        }
+        if (!escape)
+        {
+            cout << "IMPOSSIBLE" << "\n";
+        }
+    }
+}

--- a/YOUNGHWAN/백준/6593_상범빌딩.cpp
+++ b/YOUNGHWAN/백준/6593_상범빌딩.cpp
@@ -1,0 +1,95 @@
+#include <bits/stdc++.h>
+using namespace std;
+int dx[6] = {1, -1, 0, 0, 0, 0};
+int dy[6] = {0, 0, 1, -1, 0, 0};
+int dz[6] = {0, 0, 0, 0, 1, -1};
+int L, R, C;
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    while (1)
+    {
+        cin >> L >> R >> C;
+        if (L == 0 && R == 0 && C == 0)
+        {
+            break;
+        }
+        // 3개의 원소를 가질 수 있는 tuple 자료구조 활용.
+        queue<tuple<int, int, int>> Q;
+        char board[32][32][32];
+        int dist[32][32][32];
+        bool escape = false;
+
+        for (int x = 0; x < L; x++)
+        {
+            for (int y = 0; y < R; y++)
+            {
+                fill(dist[x][y], dist[x][y] + C, 0);
+            }
+        }
+
+        for (int x = 0; x < L; x++)
+        {
+            for (int y = 0; y < R; y++)
+            {
+                for (int z = 0; z < C; z++)
+                {
+                    cin >> board[x][y][z];
+                    // S면 BFS queue에 추가.(시작점 추가)
+                    if (board[x][y][z] == 'S')
+                    {
+                        Q.push({x, y, z});
+                        dist[x][y][z] = 0;
+                    }
+                    // .이면 못 가는 지역이므로 -1로 초기화
+                    else if (board[x][y][z] == '.')
+                    {
+                        dist[x][y][z] = -1;
+                    }
+                }
+            }
+        }
+        while (!Q.empty())
+        {
+            if (escape)
+            {
+                break;
+            }
+            auto cur = Q.front();
+            Q.pop();
+            int curZ, curX, curY;
+            // cur의 값을 한방에 할당
+            tie(curZ, curX, curY) = cur;
+            for (int i = 0; i < 6; i++)
+            {
+                int nz = curZ + dz[i];
+                int nx = curX + dx[i];
+                int ny = curY + dy[i];
+                if (nx < 0 || nx >= R || ny < 0 || ny >= C || nz < 0 || nz >= L)
+                {
+                    continue;
+                }
+                if (board[nz][nx][ny] == '#' || dist[nz][nx][ny] > 0)
+                {
+                    continue;
+                }
+
+                dist[nz][nx][ny] = dist[curZ][curX][curY] + 1;
+                // 탈출 조건이면 탈출
+                if (board[nz][nx][ny] == 'E')
+                {
+                    cout << "Escaped in " << dist[nz][nx][ny] << " minute(s).\n";
+                    escape = 1;
+                    break;
+                }
+                Q.push({nz, nx, ny});
+            }
+        }
+        if (!escape)
+        {
+            cout << "Trapped!" << "\n";
+        }
+    }
+}

--- a/YOUNGHWAN/백준/7569_토마토.cpp
+++ b/YOUNGHWAN/백준/7569_토마토.cpp
@@ -1,0 +1,75 @@
+#include <bits/stdc++.h>
+using namespace std;
+int board[102][102][102] = {
+    -1,
+};
+int dx[6] = {0, -1, 0, 1, 0, 0};
+int dy[6] = {1, 0, -1, 0, 0, 0};
+int dz[6] = {0, 0, 0, 0, 1, -1};
+int M, N, H;
+int main(void)
+{
+    ios_base::sync_with_stdio(0);
+    cin.tie(0);
+
+    // constraints
+    // 2 <= M <= 100 column
+    // 2 <= N <= 100 row
+    // 1 <= H <= 100 height
+    cin >> M >> N >> H;
+    queue<tuple<int, int, int>> Q; // 3차원이라 tuple 사용
+    for (int z = 0; z < H; z++)
+    {
+        for (int x = 0; x < N; x++)
+        {
+            for (int y = 0; y < M; y++)
+            {
+                cin >> board[x][y][z];
+                if (board[x][y][z] == 1)
+                {
+                    Q.push({x, y, z}); // 시작점이 여러개라 여기서 push
+                }
+            }
+        }
+    }
+    while (!Q.empty())
+    {
+        tuple<int, int, int> cur = Q.front();
+        Q.pop();
+        for (int dir = 0; dir < 6; dir++)
+        {
+            // next 좌표들
+            int nx = get<0>(cur) + dx[dir];
+            int ny = get<1>(cur) + dy[dir];
+            int nz = get<2>(cur) + dz[dir];
+
+            if (nx < 0 || nx >= N || ny < 0 || ny >= M || nz < 0 || nz >= H)
+            {
+                continue;
+            }
+            if (board[nx][ny][nz] != 0)
+            {
+                continue;
+            }
+            Q.push({nx, ny, nz});
+            board[nx][ny][nz] = board[get<0>(cur)][get<1>(cur)][get<2>(cur)] + 1;
+        }
+    }
+    int mx = 1;
+    for (int z = 0; z < H; z++)
+    {
+        for (int x = 0; x < N; x++)
+        {
+            for (int y = 0; y < M; y++)
+            {
+                if (board[x][y][z] == 0)
+                {
+                    cout << -1;
+                    return 0;
+                }
+                mx = max(board[x][y][z], mx);
+            }
+        }
+    }
+    cout << mx - 1;
+}


### PR DESCRIPTION
## 문제 번호/제목
[1074_Z](https://www.acmicpc.net/problem/1074)
[2468_안전영역](https://www.acmicpc.net/problem/2468)
[5427_불](https://www.acmicpc.net/problem/5427)
[6593_상범빌딩](https://www.acmicpc.net/problem/6593)
[7569_토마토](https://www.acmicpc.net/problem/7569)

## 코드 설명
### [1074_Z](https://www.acmicpc.net/problem/1074)
재귀 함수를 이용해 문제를 풀었다.
각 2^n * 2^n 배열을 4등분해서 몇번째인지 구하는것이므로, 케이스를 열심히 나눠서 풀었다. half라는 변수는 한 파트의 이동 지점의 값을 의미한다.

### [2468_안전영역](https://www.acmicpc.net/problem/2468)
물이 h만큼 잠겼을 때, 안전한 영역의 갯수를 구하는 문제이다. 
1. 입력으로 각 지점의 높이를 2차원 배열 형태로 입력 받는다.
2. h는 주어지지 않았고, 하나씩 brute-force 해야하기에 첫번째 반복문으로 감싼다.
3. 각 순회마다 vis배열(방문 배열)을 0으로 초기화 시킨다.
4. 완전 탐색으로 `mat[x][y] > h && !vis[x][y]` 높이가 h보다 높고, 아직 가보지 않은 지역에 대해 BFS를 진행한다.
5. BFS가 끝난 지역은 한 덩어리이기에 `cnt++`를 해줘 개수에 1을 더해준다.
6. 각 완전탐색이 끝날 때마다 최대 갯수와 비교하며,최대 갯수를 업데이트한다.
7. 최대 갯수를 출력한다.

### [5427_불](https://www.acmicpc.net/problem/5427)
시작점이 여러개일 때, 각각 방문 배열을 만들고 각각 진행한다. 
마지막에 탈출 조건은 주어진 배열 크기를 벗어났을 때 탈출했다는 것을 알렸다. 추가로 BFS 진행시 `viF[nx][ny] <= viS[curS.X][curS.Y] + 1` 이미 불이 붙은 장소는 지나지 않는 다는 것을 표시한다.

### [6593_상범빌딩](https://www.acmicpc.net/problem/6593)
3차원 BFS다. 코드에 대략적인 설명을 넣었다.

### [7569_토마토](https://www.acmicpc.net/problem/7569)
2차원의 토마토와 같은 문제이다. 이건 3차원으로 확장하여 BFS시 z-axis로 위, 아래까지 추가하여 6개의 좌표로 확산하는 문제이다.
## Reference



